### PR TITLE
Proposal: Nix Powered Checks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,12 @@
+name: checks
+
+on:
+  push:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@main
+      - run: nix flake check -Lv

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn.lock
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,184 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1728330715,
+        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": ["nixpkgs"],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1730797577,
+        "narHash": "sha256-SrID5yVpyUfknUTGWgYkTyvdr9J1LxUym4om3SVGPkg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "1864030ed24a2b8b4e4d386a5eeaf0c5369e50a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": ["git-hooks", "nixpkgs"]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1730207686,
+        "narHash": "sha256-SCHiL+1f7q9TAnxpasriP6fMarWE5H43t25F5/9e28I=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "776e68c1d014c3adde193a18db9d738458cd2ba4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722073938,
+        "narHash": "sha256-OpX0StkL8vpXyWOGUD6G+MA26wAXK6SpT94kLJXo6B4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e36e9f57337d0ff0cf77aceb58af4c805472bfae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils",
+        "git-hooks": "git-hooks",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  description = "Nodejs Dev Shell";
+
+  inputs = {
+    devshell.url = "github:numtide/devshell";
+    flake-utils.url = "github:numtide/flake-utils";
+    git-hooks = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:cachix/git-hooks.nix";
+    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+
+    nix-filter.url = "github:numtide/nix-filter";
+  };
+
+  outputs =
+    {
+      devshell,
+      flake-utils,
+      git-hooks,
+      nixpkgs,
+      nix-filter,
+      self,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        app-source = nix-filter.lib.filter {
+          root = ./.;
+          exclude = [ ];
+
+          include = [
+            "src"
+            (nix-filter.lib.matchExt "js")
+            (nix-filter.lib.matchExt "json")
+            (nix-filter.lib.matchExt "ts")
+          ];
+        };
+
+        pkg-lock = builtins.fromJSON (builtins.readFile ./package.json);
+
+        pkgs = import nixpkgs {
+          overlays = [ devshell.overlays.default ];
+          inherit system;
+        };
+      in
+      {
+        checks.git-hooks = git-hooks.lib.${system}.run {
+          src = self;
+          hooks = {
+            actionlint.enable = true;
+
+            deadnix = {
+              enable = true;
+              settings.edit = true;
+            };
+
+            nixfmt-rfc-style.enable = true;
+
+            prettier = {
+              enable = true;
+              settings.write = true;
+            };
+
+            statix.enable = true;
+
+            statix-write = {
+              enable = true;
+              name = "Statix Write";
+              entry = "${pkgs.statix}/bin/statix fix";
+              language = "system";
+              pass_filenames = false;
+            };
+
+            trufflehog-verified = {
+              enable = pkgs.stdenv.isLinux;
+              name = "Trufflehog Search";
+              entry = "${pkgs.trufflehog}/bin/trufflehog git file://. --since-commit HEAD --only-verified --fail --no-update";
+              language = "system";
+              pass_filenames = false;
+            };
+          };
+        };
+
+        devShells.default = pkgs.devshell.mkShell {
+          devshell.startup.git-hooks.text = self.checks.${system}.git-hooks.shellHook;
+          name = "dev-shell";
+          packages = with pkgs; [
+            deadnix
+            nixfmt-rfc-style
+            nodejs_20
+            nodePackages.prettier
+            nodePackages.typescript
+            statix
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+
+        packages = {
+          newwwie = pkgs.buildNpmPackage {
+            inherit (pkg-lock) version;
+            pname = "newwwie";
+            src = app-source;
+            npmDepsHash = "sha256-FGQpZmR5uSh3kLYyRPLG4KlQnnOzUxnJKeVkCVMabZM=";
+          };
+        };
+      }
+    );
+
+}


### PR DESCRIPTION
# Background
Creating this as only a proposal for now; as I had written the majority of code required for this change-set in https://github.com/newwwie/newwwie.com/pull/134 I figured I'd create it anyway.

This changeset _could_ be seem as covering https://github.com/newwwie/newwwie.com/issues/90 but has a caveat that the underlying technology is generally a unix-only option leading to a need to either:
* document how a user would utilise this approach
* throw the PR away as it is at odds with keeping to simpler technology choices

## Why
Why `nix` when it is known to have a reasonable learning curve?

### Non-Blocking
If considered suitable; I would suggest we keep the check run as not-required and instead it can provide value by providing feedback on how adherent a PR is to the listed checks above.

### Reproducibility
Nix enables reproducibility rather than just repeatability; if the checks pass on your machine utilising this mechanism, it'll absolutely pass within the checks flow also, the only possible caveat to this will be if a macOS or Windows opinion differs from Linux; only as the checks run will run under Linux; 

Between macOS and Linux I've _never_ seen this eventuate. I cannot speak for Windows; but in the Windows case I believe the only reasonable approaches to run this would be via docker anyway.

### Enabler of Auto-Merge
Currently the repository does not have auto merges enabled; this could be utilised as an approach to ensuring rigour of a changeset that enables this feature to be enabled

## Features

In essence, the added `flake.*` files and `.envrc` allow a user who has `nix` installed to run `nix flake check` to ensure all code adheres to checks described [here](https://github.com/newwwie/newwwie.com/compare/main...JayRovacsek:actions-pages-checks?expand=1#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R49):
* [actionlint](https://github.com/rhysd/actionlint) - ensures github action file suitability
* [deadnix](https://github.com/astro/deadnix) - ensures no code within `*nix` files that are evaluated is unused or proposes removing it
* [nixfmt](https://github.com/NixOS/nixfmt) - RFC candidate for the nix language
* [prettier](https://prettier.io/) - across all suitable files in the repository
* [statix](https://github.com/oppiliappan/statix) lint and recommends best practice for `*nix` code (plus the custom write check I've written enforces those opinions)
* [trufflehog](https://github.com/trufflesecurity/trufflehog) - custom hook that will attempt to identify and validate secrets committed into the repository

## How

These checks can be adopted into a workflow via [direnv](https://direnv.net/docs/installation.html) running or via [nix develop](https://nix.dev/manual/nix/2.17/command-ref/new-cli/nix3-develop) which will install the hooks at [shell start time](https://github.com/newwwie/newwwie.com/compare/main...JayRovacsek:actions-pages-checks?expand=1#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R86) and provide the [listed packages](https://github.com/newwwie/newwwie.com/compare/main...JayRovacsek:actions-pages-checks?expand=1#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R89) also as an ephemeral shell.

## Examples

An example of all checks passing is as per this [actions run](https://github.com/JayRovacsek/newwwie.com/actions/runs/11650627380/job/32439581677), if ran locally it would emit the following when in verbose mode:
![image](https://github.com/user-attachments/assets/21e46689-b33f-4350-bbee-dc8cf2269b8e)

## Further

An example of utilising this integrated with git hooks (change on the right is the modification the hook as applied, left is git error log)
![image](https://github.com/user-attachments/assets/7f762f87-e46b-477b-84f0-a42ae9ca363c)

[Treefmt](https://github.com/cachix/git-hooks.nix/blob/af8a16fe5c264f5e9e18bcee2859b40a656876cf/modules/hooks.nix#L1591) is supported by the underlying [git-hooks.nix](https://github.com/cachix/git-hooks.nix) repository and might be a good option to centralise all checks if this change-set is considered suitable.

### Next Steps
Feel free to provide feedback; good and bad; I'm happy to enable conversation to clarify anything required on the above :heart: 