### PR TITLE
fix: remove year reference in slashnew conference link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -95,7 +95,7 @@
         <a href="#invite">Get an Invite</a>
         <a href="#community">Community</a>
         <a href="#events">Events</a>
-        <a href="https://slashnew.tech/">/NEW Conference 2024</a>
+        <a href="https://slashnew.tech/">/NEW Conference</a>
       </div>
 
       <div>


### PR DESCRIPTION
As per title, removes suggestion that the conference only runs in 2024